### PR TITLE
Change build output from ES6 to ES5

### DIFF
--- a/packages/react-tiny-toast/package.json
+++ b/packages/react-tiny-toast/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "start": "tsc -w",
     "build:types": "tsc --emitDeclarationOnly",
-    "build:js": "babel src --out-dir lib --copy-files --extensions \".ts,.tsx\"",
+    "build:js": "tsc -p tsconfig.json",
     "build:clean": "rm -rf lib",
     "build": "yarn build:clean && yarn build:types && yarn build:js",
     "publish": "yarn build && npm publish"

--- a/packages/react-tiny-toast/tsconfig.json
+++ b/packages/react-tiny-toast/tsconfig.json
@@ -14,7 +14,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
+    "module": "commonjs",
     "declaration": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Hello!

I started using your package and found out that its output is in ES6 format. I suggest to change it to ES5, otherwise, all the consumers will have to transpile it themselves. I also suggest using `tsc` for building the dist, since you're using it for type check anyway. If you run `npm run build` (or `yarn build`) now you'll see that the output is in ES5 now.
So please take a look, what do you think about it?

P.S. Thanks for the nice package!